### PR TITLE
Add support for configuring the score-entry UI via the compstate

### DIFF
--- a/sr/comp/scorer/__init__.py
+++ b/sr/comp/scorer/__init__.py
@@ -1,5 +1,7 @@
 from .app import app
+from .converter import Converter
 
 __all__ = (
     'app',
+    'Converter',
 )

--- a/sr/comp/scorer/app.py
+++ b/sr/comp/scorer/app.py
@@ -4,13 +4,12 @@ import itertools
 import os
 import sys
 from datetime import datetime
-from pathlib import Path
-from typing import Type
 
 import dateutil.tz
 import flask
 
 from sr.comp.raw_compstate import RawCompstate
+from sr.comp.scorer.converter import load_converter
 from sr.comp.validation import validate
 
 app = flask.Flask('sr.comp.scorer')
@@ -62,80 +61,6 @@ def group_list_dict(matches, keys):
 def is_match_done(match):
     path = flask.g.compstate.get_score_path(match)
     return os.path.exists(path)
-
-
-class Converter:
-    @staticmethod
-    def form_team_to_score(form, zone_id):
-        return {
-            'zone': zone_id,
-            'disqualified':
-                form.get('disqualified_{}'.format(zone_id), None) is not None,
-            'present':
-                form.get('present_{}'.format(zone_id), None) is not None,
-        }
-
-    @classmethod
-    def form_to_score(cls, match, form):
-        zone_ids = range(len(match.teams))
-
-        teams = {}
-        for zone_id in zone_ids:
-            tla = form.get('tla_{}'.format(zone_id), None)
-            if tla:
-                teams[tla] = cls.form_team_to_score(form, zone_id)
-
-        zones = list(zone_ids) + ['other']
-        arena = {}
-        for zone in zones:
-            arena[zone] = {'tokens': form.get('tokens_{}'.format(zone), '')}
-
-        return {
-            'arena_id': match.arena,
-            'match_number': match.num,
-            'teams': teams,
-            'arena_zones': arena,
-        }
-
-    @staticmethod
-    def score_to_form(score):
-        form = {}
-
-        for tla, info in score['teams'].items():
-            zone_id = info['zone']
-            form['tla_{}'.format(zone_id)] = tla
-            form['disqualified_{}'.format(zone_id)] = info.get('disqualified', False)
-            form['present_{}'.format(zone_id)] = info.get('present', True)
-
-        for zone, info in score['arena_zones'].items():
-            form['tokens_{}'.format(zone)] = info['tokens'].upper()
-
-        return form
-
-    @staticmethod
-    def match_to_form(match):
-        form = {}
-
-        for zone_id, tla in enumerate(match.teams):
-            if tla:
-                form['tla_{}'.format(zone_id)] = tla
-                form['disqualified_{}'.format(zone_id)] = False
-                form['present_{}'.format(zone_id)] = False
-
-            form['tokens_{}'.format(zone_id)] = ''
-
-        form['tokens'] = ''
-
-        return form
-
-
-def load_converter(compstate_path: Path) -> Type[Converter]:
-    """
-    Load the score coverter module from Compstate repo.
-
-    :param Path compstate_path: The path to the compstate repo.
-    """
-    return Converter
 
 
 def update_and_validate(compstate, match, score, force):

--- a/sr/comp/scorer/app.py
+++ b/sr/comp/scorer/app.py
@@ -4,6 +4,8 @@ import itertools
 import os
 import sys
 from datetime import datetime
+from pathlib import Path
+from typing import Type
 
 import dateutil.tz
 import flask
@@ -62,69 +64,78 @@ def is_match_done(match):
     return os.path.exists(path)
 
 
-def form_to_score(match, form):
+class Converter:
+    @staticmethod
+    def form_team_to_score(form, zone_id):
+        return {
+            'zone': zone_id,
+            'disqualified':
+                form.get('disqualified_{}'.format(zone_id), None) is not None,
+            'present':
+                form.get('present_{}'.format(zone_id), None) is not None,
+        }
 
-    def form_team_to_score(zone_id, teams):
-        tla = form.get('tla_{}'.format(zone_id), None)
-        if tla:
-            team = {
-                'zone': zone_id,
-                'disqualified':
-                    form.get('disqualified_{}'.format(zone_id), None) is not None,
-                'present':
-                    form.get('present_{}'.format(zone_id), None) is not None,
-            }
+    @classmethod
+    def form_to_score(cls, match, form):
+        zone_ids = range(len(match.teams))
 
-            teams[tla] = team
+        teams = {}
+        for zone_id in zone_ids:
+            tla = form.get('tla_{}'.format(zone_id), None)
+            if tla:
+                teams[tla] = cls.form_team_to_score(form, zone_id)
 
-    zone_ids = range(len(match.teams))
+        zones = list(zone_ids) + ['other']
+        arena = {}
+        for zone in zones:
+            arena[zone] = {'tokens': form.get('tokens_{}'.format(zone), '')}
 
-    teams = {}
-    for zone_id in zone_ids:
-        form_team_to_score(zone_id, teams)
+        return {
+            'arena_id': match.arena,
+            'match_number': match.num,
+            'teams': teams,
+            'arena_zones': arena,
+        }
 
-    zones = list(zone_ids) + ['other']
-    arena = {}
-    for zone in zones:
-        arena[zone] = {'tokens': form.get('tokens_{}'.format(zone), '')}
+    @staticmethod
+    def score_to_form(score):
+        form = {}
 
-    return {
-        'arena_id': match.arena,
-        'match_number': match.num,
-        'teams': teams,
-        'arena_zones': arena,
-    }
-
-
-def score_to_form(score):
-    form = {}
-
-    for tla, info in score['teams'].items():
-        zone_id = info['zone']
-        form['tla_{}'.format(zone_id)] = tla
-        form['disqualified_{}'.format(zone_id)] = info.get('disqualified', False)
-        form['present_{}'.format(zone_id)] = info.get('present', True)
-
-    for zone, info in score['arena_zones'].items():
-        form['tokens_{}'.format(zone)] = info['tokens'].upper()
-
-    return form
-
-
-def match_to_form(match):
-    form = {}
-
-    for zone_id, tla in enumerate(match.teams):
-        if tla:
+        for tla, info in score['teams'].items():
+            zone_id = info['zone']
             form['tla_{}'.format(zone_id)] = tla
-            form['disqualified_{}'.format(zone_id)] = False
-            form['present_{}'.format(zone_id)] = False
+            form['disqualified_{}'.format(zone_id)] = info.get('disqualified', False)
+            form['present_{}'.format(zone_id)] = info.get('present', True)
 
-        form['tokens_{}'.format(zone_id)] = ''
+        for zone, info in score['arena_zones'].items():
+            form['tokens_{}'.format(zone)] = info['tokens'].upper()
 
-    form['tokens'] = ''
+        return form
 
-    return form
+    @staticmethod
+    def match_to_form(match):
+        form = {}
+
+        for zone_id, tla in enumerate(match.teams):
+            if tla:
+                form['tla_{}'.format(zone_id)] = tla
+                form['disqualified_{}'.format(zone_id)] = False
+                form['present_{}'.format(zone_id)] = False
+
+            form['tokens_{}'.format(zone_id)] = ''
+
+        form['tokens'] = ''
+
+        return form
+
+
+def load_converter(compstate_path: Path) -> Type[Converter]:
+    """
+    Load the score coverter module from Compstate repo.
+
+    :param Path compstate_path: The path to the compstate repo.
+    """
+    return Converter
 
 
 def update_and_validate(compstate, match, score, force):
@@ -206,6 +217,8 @@ def update(arena, num):
     compstate = flask.g.compstate
     comp = compstate.load()
 
+    converter = load_converter(comp.root)
+
     try:
         match = comp.schedule.matches[num][arena]
     except (IndexError, KeyError):
@@ -222,12 +235,12 @@ def update(arena, num):
         try:
             score = compstate.load_score(match)
         except IOError:
-            flask.request.form = match_to_form(match)
+            flask.request.form = converter.match_to_form(match)
         else:
-            flask.request.form = score_to_form(score)
+            flask.request.form = converter.score_to_form(score)
     elif flask.request.method == 'POST':
         try:
-            score = form_to_score(match, flask.request.form)
+            score = converter.form_to_score(match, flask.request.form)
         except ValueError as e:
             return flask.render_template(
                 'update.html',

--- a/sr/comp/scorer/app.py
+++ b/sr/comp/scorer/app.py
@@ -171,7 +171,7 @@ def update(arena, num):
     compstate = flask.g.compstate
     comp = compstate.load()
 
-    converter = load_converter(comp.root)
+    converter = load_converter(comp.root)()
 
     try:
         match = comp.schedule.matches[num][arena]

--- a/sr/comp/scorer/converter.py
+++ b/sr/comp/scorer/converter.py
@@ -65,7 +65,7 @@ class Converter:
             form['disqualified_{}'.format(zone_id)] = info.get('disqualified', False)
             form['present_{}'.format(zone_id)] = info.get('present', True)
 
-        for zone, info in score['arena_zones'].items():
+        for zone, info in score.get('arena_zones', {}).items():
             form['tokens_{}'.format(zone)] = info['tokens'].upper()
 
         return form

--- a/sr/comp/scorer/converter.py
+++ b/sr/comp/scorer/converter.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+from typing import Type
+
+
+class Converter:
+    """
+    Base class for converting between representations of a match's score.
+    """
+
+    @staticmethod
+    def form_team_to_score(form, zone_id):
+        return {
+            'zone': zone_id,
+            'disqualified':
+                form.get('disqualified_{}'.format(zone_id), None) is not None,
+            'present':
+                form.get('present_{}'.format(zone_id), None) is not None,
+        }
+
+    @classmethod
+    def form_to_score(cls, match, form):
+        zone_ids = range(len(match.teams))
+
+        teams = {}
+        for zone_id in zone_ids:
+            tla = form.get('tla_{}'.format(zone_id), None)
+            if tla:
+                teams[tla] = cls.form_team_to_score(form, zone_id)
+
+        zones = list(zone_ids) + ['other']
+        arena = {}
+        for zone in zones:
+            arena[zone] = {'tokens': form.get('tokens_{}'.format(zone), '')}
+
+        return {
+            'arena_id': match.arena,
+            'match_number': match.num,
+            'teams': teams,
+            'arena_zones': arena,
+        }
+
+    @staticmethod
+    def score_to_form(score):
+        form = {}
+
+        for tla, info in score['teams'].items():
+            zone_id = info['zone']
+            form['tla_{}'.format(zone_id)] = tla
+            form['disqualified_{}'.format(zone_id)] = info.get('disqualified', False)
+            form['present_{}'.format(zone_id)] = info.get('present', True)
+
+        for zone, info in score['arena_zones'].items():
+            form['tokens_{}'.format(zone)] = info['tokens'].upper()
+
+        return form
+
+    @staticmethod
+    def match_to_form(match):
+        form = {}
+
+        for zone_id, tla in enumerate(match.teams):
+            if tla:
+                form['tla_{}'.format(zone_id)] = tla
+                form['disqualified_{}'.format(zone_id)] = False
+                form['present_{}'.format(zone_id)] = False
+
+            form['tokens_{}'.format(zone_id)] = ''
+
+        form['tokens'] = ''
+
+        return form
+
+
+def load_converter(compstate_path: Path) -> Type[Converter]:
+    """
+    Load the score coverter module from Compstate repo.
+
+    :param Path compstate_path: The path to the compstate repo.
+    """
+    return Converter

--- a/sr/comp/scorer/converter.py
+++ b/sr/comp/scorer/converter.py
@@ -1,5 +1,10 @@
+import copy
+import imp
+import sys
 from pathlib import Path
-from typing import Type
+from typing import cast, Dict, Type, Union
+
+from sr.comp.match_period import Match
 
 
 class Converter:
@@ -97,4 +102,17 @@ def load_converter(compstate_path: Path) -> Type[Converter]:
 
     :param Path compstate_path: The path to the compstate repo.
     """
-    return Converter
+
+    # Deep path hacks
+    score_directory = compstate_path / 'scoring'
+    converter_source = score_directory / 'converter.py'
+
+    saved_path = copy.copy(sys.path)
+    sys.path.append(str(score_directory))
+
+    imported_library = imp.load_source('converter.py', str(converter_source))
+
+    sys.path = saved_path
+
+    converter = imported_library.Converter  # type: ignore[attr-defined]
+    return cast(Type[Converter], converter)

--- a/sr/comp/scorer/converter.py
+++ b/sr/comp/scorer/converter.py
@@ -12,8 +12,7 @@ class Converter:
     Base class for converting between representations of a match's score.
     """
 
-    @staticmethod
-    def form_team_to_score(form, zone_id):
+    def form_team_to_score(self, form, zone_id):
         """
         Prepare the part of the score dict for the given zone from the form data.
         """
@@ -25,8 +24,7 @@ class Converter:
                 form.get('present_{}'.format(zone_id), None) is not None,
         }
 
-    @classmethod
-    def form_to_score(cls, match, form):
+    def form_to_score(self, match, form):
         """
         Prepare a score dict for the given match and form dict.
 
@@ -39,7 +37,7 @@ class Converter:
         for zone_id in zone_ids:
             tla = form.get('tla_{}'.format(zone_id), None)
             if tla:
-                teams[tla] = cls.form_team_to_score(form, zone_id)
+                teams[tla] = self.form_team_to_score(form, zone_id)
 
         zones = list(zone_ids) + ['other']
         arena = {}
@@ -53,8 +51,7 @@ class Converter:
             'arena_zones': arena,
         }
 
-    @staticmethod
-    def score_to_form(score):
+    def score_to_form(self, score):
         """
         Prepare a form dict for the given score dict.
 
@@ -73,8 +70,7 @@ class Converter:
 
         return form
 
-    @staticmethod
-    def match_to_form(match: Match) -> Dict[str, Union[str, bool]]:
+    def match_to_form(self, match: Match) -> Dict[str, Union[str, bool]]:
         """
         Prepare a fresh form dict for the given match.
 

--- a/sr/comp/scorer/converter.py
+++ b/sr/comp/scorer/converter.py
@@ -9,6 +9,9 @@ class Converter:
 
     @staticmethod
     def form_team_to_score(form, zone_id):
+        """
+        Prepare the part of the score dict for the given zone from the form data.
+        """
         return {
             'zone': zone_id,
             'disqualified':
@@ -19,6 +22,12 @@ class Converter:
 
     @classmethod
     def form_to_score(cls, match, form):
+        """
+        Prepare a score dict for the given match and form dict.
+
+        This method is used to convert the submitted information for storage as
+        YAML in the compstate.
+        """
         zone_ids = range(len(match.teams))
 
         teams = {}
@@ -41,6 +50,11 @@ class Converter:
 
     @staticmethod
     def score_to_form(score):
+        """
+        Prepare a form dict for the given score dict.
+
+        This method is used when there is an existing score for a match.
+        """
         form = {}
 
         for tla, info in score['teams'].items():
@@ -55,8 +69,14 @@ class Converter:
         return form
 
     @staticmethod
-    def match_to_form(match):
-        form = {}
+    def match_to_form(match: Match) -> Dict[str, Union[str, bool]]:
+        """
+        Prepare a fresh form dict for the given match.
+
+        This method is used when there is no existing score for a match.
+        """
+
+        form = {}  # type: Dict[str, Union[str, bool]]
 
         for zone_id, tla in enumerate(match.teams):
             if tla:

--- a/sr/comp/scorer/templates/_update.html
+++ b/sr/comp/scorer/templates/_update.html
@@ -79,46 +79,53 @@
         </h1>
 
         <form method="POST">
-            <svg xmlns="http://www.w3.org/2000/svg" height="600" width="600" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink">
-                <rect height="600" width="600" stroke="#000" y="0" x="0" stroke-width="2" fill="#f4f3ff"/>
-                <path d="M300 0 V 600" stroke="#000" stroke-width="1"/>
-                <path d="M0 300 H 600" stroke="#000" stroke-width="1"/>
-                <rect height="200" width="200" stroke="#000" y="200" x="200" stroke-width="1" fill="#f4f3ff" transform="rotate(45,300,300)"/>
+            {% block form_content %}
+                <svg xmlns="http://www.w3.org/2000/svg" height="600" width="600" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <rect height="600" width="600" stroke="#000" y="0" x="0" stroke-width="2" fill="#f4f3ff"/>
+                    <path d="M300 0 V 600" stroke="#000" stroke-width="1"/>
+                    <path d="M0 300 H 600" stroke="#000" stroke-width="1"/>
+                    <rect height="200" width="200" stroke="#000" y="200" x="200" stroke-width="1" fill="#f4f3ff" transform="rotate(45,300,300)"/>
 
-                <g font-size="2.5em" fill="#4d4d4d" transform="scale(0.75 0.75)">
-                    <text><tspan y="50" x="225" stroke="{{ corners[0].colour }}">Zone 0</tspan></text>
-                    <text><tspan y="50" x="455" stroke="{{ corners[1].colour }}">Zone 1</tspan></text>
-                    <text><tspan y="775" x="455" stroke="{{ corners[2].colour }}">Zone 2</tspan></text>
-                    <text><tspan y="775" x="225" stroke="{{ corners[3].colour }}">Zone 3</tspan></text>
-                </g>
+                    <g font-size="2.5em" fill="#4d4d4d" transform="scale(0.75 0.75)">
+                        <text><tspan y="50" x="225" stroke="{{ corners[0].colour }}">Zone 0</tspan></text>
+                        <text><tspan y="50" x="455" stroke="{{ corners[1].colour }}">Zone 1</tspan></text>
+                        <text><tspan y="775" x="455" stroke="{{ corners[2].colour }}">Zone 2</tspan></text>
+                        <text><tspan y="775" x="225" stroke="{{ corners[3].colour }}">Zone 3</tspan></text>
+                    </g>
 
-                <!-- Zone 0 -->
-                {{ input_tla(110, 70, 0) }}
-                {{ input_tokens(60, 120, 0) }}
-                {{ input_present(80, 170, 0) }}
-                {{ input_disqualified(35, 220, 0) }}
+                    {% block zone_0 %}
+                        {{ input_tla(110, 70, 0) }}
+                        {{ input_tokens(60, 120, 0) }}
+                        {{ input_present(80, 170, 0) }}
+                        {{ input_disqualified(35, 220, 0) }}
+                    {% endblock %}
 
-                <!-- Zone 1 -->
-                {{ input_tla(345, 70, 1) }}
-                {{ input_tokens(355, 120, 1) }}
-                {{ input_present(405, 170, 1) }}
-                {{ input_disqualified(410, 220, 1) }}
+                    {% block zone_1 %}
+                        {{ input_tla(345, 70, 1) }}
+                        {{ input_tokens(355, 120, 1) }}
+                        {{ input_present(405, 170, 1) }}
+                        {{ input_disqualified(410, 220, 1) }}
+                    {% endblock %}
 
-                <!-- Zone 2 -->
-                {{ input_tla(425, 350, 2) }}
-                {{ input_tokens(370, 400, 2) }}
-                {{ input_present(385, 450, 2) }}
-                {{ input_disqualified(335, 500, 2) }}
+                    {% block zone_2 %}
+                        {{ input_tla(425, 350, 2) }}
+                        {{ input_tokens(370, 400, 2) }}
+                        {{ input_present(385, 450, 2) }}
+                        {{ input_disqualified(335, 500, 2) }}
+                    {% endblock %}
 
-                <!-- Zone 3 -->
-                {{ input_tla(30, 350, 3) }}
-                {{ input_tokens(45, 400, 3) }}
-                {{ input_present(100, 450, 3) }}
-                {{ input_disqualified(110, 500, 3) }}
+                    {% block zone_3 %}
+                        {{ input_tla(30, 350, 3) }}
+                        {{ input_tokens(45, 400, 3) }}
+                        {{ input_present(100, 450, 3) }}
+                        {{ input_disqualified(110, 500, 3) }}
+                    {% endblock %}
 
-                <!-- Center -->
-                {{ input_tokens(200, 285, 'other') }}
-            </svg>
+                    {% block zone_other %}
+                        {{ input_tokens(200, 285, 'other') }}
+                    {% endblock %}
+                </svg>
+            {% endblock %}
 
             <input type="hidden" name="force" />
             <input type="submit" value="Enter Scores" />
@@ -185,24 +192,28 @@
         </script>
     {% endif %}
 
-    <script type="text/javascript">
-        var valid_token_regex = /^[GOPWY]*$/;
+    {% block script %}
+        <script type="text/javascript">
+            {% block valid_token_regex %}
+                var valid_token_regex = /^[GOPWY]*$/;
+            {% endblock %}
 
-        var token_input_change = function(input) {
-            input.value = input.value.toUpperCase();
-            validate_token_input(input);
-        };
-        var validate_token_input = function(input) {
-            if (input.value.match(valid_token_regex)) {
-                input.className = '';
-            } else {
-                input.className = 'invalid';
+            var token_input_change = function(input) {
+                input.value = input.value.toUpperCase();
+                validate_token_input(input);
+            };
+            var validate_token_input = function(input) {
+                if (input.value.match(valid_token_regex)) {
+                    input.className = '';
+                } else {
+                    input.className = 'invalid';
+                }
+            };
+
+            var tokenInputs = document.querySelectorAll('input[type=text].tokens');
+            for (var i = 0; i < tokenInputs.length; i++) {
+                validate_token_input(tokenInputs[i]);
             }
-        };
-
-        var tokenInputs = document.querySelectorAll('input[type=text].tokens');
-        for (var i = 0; i < tokenInputs.length; i++) {
-            validate_token_input(tokenInputs[i]);
-        }
-    </script>
+        </script>
+    {% endblock %}
 {% endblock %}


### PR DESCRIPTION
This takes inspiration from the way that the compstates contain the actual scoring logic and applies it to the score-entry UI.
Specifically, this requires that a compstate:
- provide a `scoring/update.html` file which is a Jinja 2 template with a suitable HTML form
- provide a `scoring/converter.py` file which contains a `Converter` class for converting data:
  - match info -> form data
  - score data - > form data
  - form data -> score data

To aid with these, the existing logic for each is exposed as a base template and base class respectively.

See https://github.com/srobo/sr2020-comp/pull/2 or https://github.com/PeterJCLaw/dummy-comp/commit/9e3fe437e8ffe2557fdf62c8b72bb7010d598711 for examples of converters.