### PR TITLE
Move to supporting only more recent Python: 3.10 to 3.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,11 +99,11 @@ references:
   python-full-version-matrix: &python-full-version-matrix
     matrix:
       parameters:
-        version: ["3.9", "3.10", "3.11", "3.12"]
+        version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
   python-top-and-bottom-version-matrix: &python-top-and-bottom-version-matrix
     matrix:
       parameters:
-        version: ["3.9", "3.12"]
+        version: ["3.10", "3.14"]
   filter-tags: &filter-tags
     filters:
       branches:

--- a/setup.py
+++ b/setup.py
@@ -29,15 +29,16 @@ setup(
         # srcomp).
         'deploy': ['libproton'],
     },
-    python_requires='>=3.9',
+    python_requires='>=3.10',
     classifiers=[
         'Intended Audience :: Information Technology',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: WSGI :: Application',


### PR DESCRIPTION
This drops support for Python 3.9, which is beyond end-of-life.